### PR TITLE
feat(demo): Bare bones dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 src/*
 test/*
 node_modules/
+site/bundle.js

--- a/package.json
+++ b/package.json
@@ -11,10 +11,14 @@
     "ava": "^0.12.0",
     "babel-cli": "6.6.4",
     "babel-plugin-transform-es2015-destructuring": "^6.6.5",
-    "babel-preset-es2015": "^6.6.0"
+    "babel-preset-es2015": "^6.6.0",
+    "browser-sync": "^2.12.10",
+    "browserify": "^13.0.1"
   },
   "scripts": {
+    "start": "scripts/server.js",
     "babel": "babel ./babel/ -d .",
+    "browserify": "browserify site/scripts/main.js > site/bundle.js",
     "test": "ava",
     "test-es5": "ava"
   },

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+'use strict';
+
+const execSync = require('child_process').execSync;
+
+let browserSync = require('browser-sync').create();
+
+execSync('npm run babel; npm run browserify', { stdio: [0, 1, 2] });
+
+browserSync.init({
+    server: 'site',
+    files: [
+        'site/index.html'
+    ]
+});
+
+browserSync.watch('site/scripts/main.js', (event) => {
+    if (event === 'change') {
+        execSync('npm run browserify', { stdio: [0, 1, 2] });
+    }
+});
+
+browserSync.watch('babel/src/*.js', (event) => {
+    if (event === 'change') {
+        execSync('npm run babel', { stdio: [0, 1, 2] });
+        execSync('npm run browserify', { stdio: [0, 1, 2] });
+    }
+});

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+  </body>
+  <script src="bundle.js"></script>
+</html>

--- a/site/scripts/main.js
+++ b/site/scripts/main.js
@@ -1,0 +1,7 @@
+'use strict';
+
+let board = require('../../src/board');
+
+let b = new board.Board();
+
+console.log(b.orbs);


### PR DESCRIPTION
Running `npm start` should automatically open a browser window to localhost:3000, and from there, `console.log` to [your browser's developer tools](https://developer.chrome.com/devtools) a `new Board().orbs`.

<img width="382" alt="screen shot 2016-05-28 at 22 06 39" src="https://cloud.githubusercontent.com/assets/1214609/15631160/7bca3c6e-2520-11e6-85f7-fff4ad704547.png">
