### PR TITLE
feat(attic): Establish attic syntax

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
     "presets": ["es2015"],
-    "plugins": ["transform-es2015-destructuring"]
+    "plugins": ["transform-es2015-destructuring", "transform-es2015-parameters"]
 }

--- a/babel/src/board.js
+++ b/babel/src/board.js
@@ -4,18 +4,14 @@ import * as orbs from './orbs';
 import * as triples from './triples';
 
 export class Board {
-    constructor (width = 8, height = 8, types = _.range(7), atticOrbs = undefined) {
+    constructor (width = 8, height = 8, types = _.range(7), atticTypes = types) {
         this.width = width;
         this.height = height;
         this.types = types;
+        this.atticTypes = atticTypes;
         this.orbs = this.generateOrbs();
         if (this.hasMatch() || this.needsShuffle()) {
             this.shuffle();
-        };
-        if (atticOrbs) {
-            this.atticOrbs = atticOrbs;
-        } else {
-            this.atticOrbs = _.cloneDeep(new Board(this.width, this.height, this.types, true).orbs);
         };
     }
 
@@ -33,6 +29,10 @@ export class Board {
     
     get matches() {
         return triples.combine(this.triples);
+    }
+    
+    get atticOrbs() {
+        return _.cloneDeep(new Board(this.width, this.height, this.atticTypes).orbs);
     }
     
     generateOrbs(types = this.types) {

--- a/babel/src/board.js
+++ b/babel/src/board.js
@@ -4,14 +4,16 @@ import * as orbs from './orbs';
 import * as triples from './triples';
 
 export class Board {
-    constructor (width = 8, height = 8, types = _.range(7), atticTypes = types) {
+    constructor (width = 8, height = 8, types = _.range(7), needsAttic = true) {
         this.width = width;
         this.height = height;
         this.types = types;
-        this.atticTypes = atticTypes;
-        this.orbs = this.generateOrbs();
+        this.generateOrbs();
         if (this.hasMatch() || this.needsShuffle()) {
             this.shuffle();
+        };
+        if (needsAttic) {
+            this.attic = new Board(this.width, this.height, this.types, false);
         };
     }
 
@@ -31,22 +33,14 @@ export class Board {
         return triples.combine(this.triples);
     }
     
-    get atticOrbs() {
-        return _.cloneDeep(new Board(this.width, this.height, this.atticTypes).orbs);
-    }
-    
-    generateOrbs(types = this.types) {
-        let chooseOrb = () => { return _.sample(types); };
+    generateOrbs() {
+        let chooseOrb = () => { return _.sample(this.types); };
         let sampleRow = () => { return _.times(this.width, chooseOrb); };
-        return _.zip(..._.times(this.height, sampleRow));
-    }
-    
-    resetAttic(types = this.types) {
-        this.atticOrbs = _.cloneDeep(new Board(this.width, this.height, types, true).orbs);
+        this.orbs = _.zip(..._.times(this.height, sampleRow));
     }
 
     evaluate() {
-        let [newOrbs, matchData] = orbs.evaluate(this.orbs, this.height, this.width, this.matches, this.atticOrbs);
+        let [newOrbs, matchData] = orbs.evaluate(this.orbs, this.height, this.width, this.matches, this.attic.orbs);
         this.orbs = newOrbs;
         return matchData;
 

--- a/babel/src/orbs.js
+++ b/babel/src/orbs.js
@@ -84,7 +84,7 @@ export function getBlanksBelow(orbs) {
 
 /**
   * @description Drops down unaffected orbs into their new post-evaluated position.
-  * NOTE: The orbs in the top rows that will be replaced with atticOrbs are left unchanged
+  * NOTE: The orbs in the top rows that will be replaced with attic.orbs are left unchanged
   * by this function.
   */
 export function activateGravity(orbs) {

--- a/babel/test/board.spec.js
+++ b/babel/test/board.spec.js
@@ -31,16 +31,18 @@ test('should have at least one possible match set and should not have a match ev
 test('attic orbs should have at least one possible match set and should not have a match event by default', t => {
     _.each(_.range(100), i => {
         board = new Board();
-        t.ok(orbs.hasPotentialMatch(board.atticOrbs) && !Boolean(triples.find(board.atticOrbs)[0]));
+        t.ok(orbs.hasPotentialMatch(board.attic.orbs) && !Boolean(triples.find(board.attic.orbs)[0]));
     });
 });
 
-test('unique attic orbs types can be assigned', t => {
-    let atticBoard1 = new Board(8, 8, _.range(5), _.range(5, 10));
-    t.same(atticBoard1.atticTypes, _.uniq(_.flatten(atticBoard1.atticOrbs)).sort());
+test('unique attic orb types can be assigned', t => {
+    let atticBoard1 = new Board(8, 8, _.range(5));
+    atticBoard1.attic.types = _.range(5, 10);
+    atticBoard1.attic.generateOrbs();
+    t.same(_.range(5, 10), _.uniq(_.flatten(atticBoard1.attic.orbs)).sort());
 });
 
-test.skip('attic orbs can be set manually', t => {
+test('attic orbs can be set manually', t => {
     let testAttic = [
         [0, 1, 2, 3, 4, 5, 6, 7],
         [0, 1, 2, 3, 4, 5, 6, 7],
@@ -51,6 +53,7 @@ test.skip('attic orbs can be set manually', t => {
         [0, 1, 2, 3, 4, 5, 6, 7],
         [0, 1, 2, 3, 4, 5, 6, 7]
     ];
-    let atticBoard2 = new Board(8, 8, _.range(8), testAttic);
-    t.is(atticBoard2.atticOrbs, testAttic);
+    let atticBoard2 = new Board();
+    atticBoard2.attic.orbs = testAttic;
+    t.is(atticBoard2.attic.orbs, testAttic);
 });

--- a/babel/test/board.spec.js
+++ b/babel/test/board.spec.js
@@ -35,7 +35,12 @@ test('attic orbs should have at least one possible match set and should not have
     });
 });
 
-test('attic orbs can be set manually', t => {
+test('unique attic orbs types can be assigned', t => {
+    let atticBoard1 = new Board(8, 8, _.range(5), _.range(5, 10));
+    t.same(atticBoard1.atticTypes, _.uniq(_.flatten(atticBoard1.atticOrbs)).sort());
+});
+
+test.skip('attic orbs can be set manually', t => {
     let testAttic = [
         [0, 1, 2, 3, 4, 5, 6, 7],
         [0, 1, 2, 3, 4, 5, 6, 7],
@@ -46,6 +51,6 @@ test('attic orbs can be set manually', t => {
         [0, 1, 2, 3, 4, 5, 6, 7],
         [0, 1, 2, 3, 4, 5, 6, 7]
     ];
-    let atticBoard = new Board(8, 8, _.range(8), testAttic);
-    t.is(atticBoard.atticOrbs, testAttic);
+    let atticBoard2 = new Board(8, 8, _.range(8), testAttic);
+    t.is(atticBoard2.atticOrbs, testAttic);
 });

--- a/babel/test/evaluate.js
+++ b/babel/test/evaluate.js
@@ -44,7 +44,8 @@ testBoards -> {
 let testBoards = {};
 _.each(boards, (metadata, name) => {
     boardInstance.orbs = _.cloneDeep(metadata.orbs);
-    boardInstance.atticTypes = [6, 7, 8, 9, 0];
+    boardInstance.attic.types = [6, 7, 8, 9, 0];
+    boardInstance.attic.generateOrbs();
     testBoards[name] = {};
     testBoards[name].matchData = boardInstance.evaluate();
     testBoards[name].evaluatedOrbs = boardInstance.orbs;

--- a/babel/test/evaluate.js
+++ b/babel/test/evaluate.js
@@ -44,8 +44,7 @@ testBoards -> {
 let testBoards = {};
 _.each(boards, (metadata, name) => {
     boardInstance.orbs = _.cloneDeep(metadata.orbs);
-    boardInstance.attic.types = [6, 7, 8, 9, 0];
-    boardInstance.attic.generateOrbs();
+    boardInstance.attic.orbs = attic.orbs;
     testBoards[name] = {};
     testBoards[name].matchData = boardInstance.evaluate();
     testBoards[name].evaluatedOrbs = boardInstance.orbs;
@@ -74,9 +73,7 @@ _.each(boards, (metadata, name) => {
         _.each(metadata.evaluate.atticOrbsDropped, section => {
             let [sliceData, droppedAtticOrbs] = section;
             let [row, start, end] = sliceData;
-            _.each(_.slice(testBoards[name].evaluatedOrbs[row], start, end), orb => {
-                t.true(_.includes([6, 7, 8, 9, 0], orb))
-            });
+            t.ok(_.isEqual(_.slice(testBoards[name].evaluatedOrbs[row], start, end), droppedAtticOrbs));
         });
     });
     

--- a/babel/test/evaluate.js
+++ b/babel/test/evaluate.js
@@ -44,7 +44,7 @@ testBoards -> {
 let testBoards = {};
 _.each(boards, (metadata, name) => {
     boardInstance.orbs = _.cloneDeep(metadata.orbs);
-    boardInstance.atticOrbs = _.cloneDeep(attic.orbs);
+    boardInstance.atticTypes = [6, 7, 8, 9, 0];
     testBoards[name] = {};
     testBoards[name].matchData = boardInstance.evaluate();
     testBoards[name].evaluatedOrbs = boardInstance.orbs;
@@ -73,7 +73,9 @@ _.each(boards, (metadata, name) => {
         _.each(metadata.evaluate.atticOrbsDropped, section => {
             let [sliceData, droppedAtticOrbs] = section;
             let [row, start, end] = sliceData;
-            t.ok(_.isEqual(_.slice(testBoards[name].evaluatedOrbs[row], start, end), droppedAtticOrbs));
+            _.each(_.slice(testBoards[name].evaluatedOrbs[row], start, end), orb => {
+                t.true(_.includes([6, 7, 8, 9, 0], orb))
+            });
         });
     });
     


### PR DESCRIPTION
This stops the constructor from calling tiself from within itself.
Instead, whenever atticOrbs are referenced, they are created on the
spot. Additionally, there is now an atticTypes parameter in the
constructor that defaults to the previously given types parameter.

This way, at any point, atticTypes can be changed, which will affect
the contents of the attic when they are called for.

This change also prevents atticOrbs from being hardcoded.
