### PR TITLE
Fix issues around attic orb referencing and resetting

### DIFF
--- a/site/scripts/demotools.js
+++ b/site/scripts/demotools.js
@@ -65,7 +65,7 @@ function evaluate(board) {
     // after the attic has been released, update the js board and repopulate
     atticEl.addEventListener(transitionEvent, function() {
         board.resetAttic();
-        animate.repopulate(board.orbs, board.atticOrbs);
+        animate.repopulate(board.orbs, board.attic.orbs);
         if (board.hasMatch()) {
             evaluate(board);
         }
@@ -91,7 +91,7 @@ exports.makeMove = function(board, swapOrbs) {
         // after the swap is done, evaluate the board
         let swapEl = document.getElementById(`main ${swapOrbs[0][0]} ${swapOrbs[0][1]}`);
         swapEl.addEventListener(whichTransitionEvent(), function() {
-            animate.repopulate(board.orbs, board.atticOrbs);
+            animate.repopulate(board.orbs, board.attic.orbs);
             evaluate(board);
         });
     }

--- a/site/scripts/main.js
+++ b/site/scripts/main.js
@@ -14,7 +14,7 @@ animate.createHTMLBoard(b.orbs);
 
 // create the atticOrbs orb set and append it to 'attic' div
 let atticBoard = document.getElementById('attic');
-animate.createHTMLAttic(b.atticOrbs);
+animate.createHTMLAttic(b.attic.orbs);
 
 // create a scoreboard for each orb type
 let types = document.getElementById('types');

--- a/typescript/src/board.ts
+++ b/typescript/src/board.ts
@@ -47,6 +47,10 @@ export class Board {
         this.orbs = _.zip(..._.times(this.height, sampleRow));
     }
 
+    resetAttic(): void {
+        this.attic = new Board(this.width, this.height, this.types, false);
+    }
+
     evaluate(): MatchData {
         let [newOrbs, matchData] = orbs.evaluate(this.orbs, this.matches, this.attic.orbs);
         this.orbs = newOrbs;


### PR DESCRIPTION
After pulling down the current master and attempting to run the demo site it was unable to generate the attic board.

This resolves naming issues with the board, and an issue where `resetAttic()` is no longer defined.

It appears to have been lost sometime after commit af6f5aad952f5e22e65fcc32ef61e528fd658b2e

There does seem to be a bug with the orbs dropped from the attic not always displaying in the first row, but no console errors, and them popping in on the next orb match, suggests it might be an issue with the rendering code.