### PR TITLE
Shake some dust off of this project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ src/*
 test/*
 node_modules/
 site-gh-pages/
-typings/
 
 # exclude in tsconfig.json is not excluding this file because other files depend on it
 types.js

--- a/package.json
+++ b/package.json
@@ -9,15 +9,15 @@
   },
   "dependencies": {
     "collections": "^3.0.0",
-    "lodash": "4.6.1"
+    "lodash": "^4.6.1",
+    "typescript": "^2.5.3"
   },
   "devDependencies": {
+    "@types/lodash": "^4.14.77",
     "ava": "^0.15.2",
     "browser-sync": "^2.12.10",
     "browserify": "^13.0.1",
-    "remarkable": "^1.6.2",
-    "typescript": "^1.8.10",
-    "typings": "^1.3.1"
+    "remarkable": "^1.6.2"
   },
   "scripts": {
     "start": "scripts/server.js",

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -5,7 +5,7 @@ const execSync = require('child_process').execSync;
 
 let browserSync = require('browser-sync').create();
 
-execSync('tsc; npm run browserify; node site/scripts/generateReadme.js; cp ./site/*.css ./site-gh-pages; cp ./site/*.html ./site-gh-pages', { stdio: [0, 1, 2] });
+execSync('mkdir -p site-gh-pages; tsc; npm run browserify; node site/scripts/generateReadme.js; cp ./site/*.css ./site-gh-pages; cp ./site/*.html ./site-gh-pages', { stdio: [0, 1, 2] });
 
 browserSync.init({
     server: 'site-gh-pages',

--- a/typings.json
+++ b/typings.json
@@ -1,5 +1,0 @@
-{
-  "dependencies": {
-    "lodash": "registry:npm/lodash#4.0.0+20160701205107"
-  }
-}


### PR DESCRIPTION
### What is changed?
- The `typescript` dependency has been updated to the latest version.
- The project now uses `@types` instead of the good old `typings` for 3rd party module types
- The `npm start` command now kicks up the dev server, including a working demo.
    - the dev environment was dependent on having a `site-gh-pages` directory which includes the final bundled js file. That set up does not seem to be a great way of organizing the site, but for now it is back working.
